### PR TITLE
Best pair selection method added as requested by Artur

### DIFF
--- a/HMuMuTree.C
+++ b/HMuMuTree.C
@@ -78,3 +78,59 @@ bool HMuMuTree::pairSelection(unsigned int iPair){
 }
 /////////////////////////////////////////////////
 /////////////////////////////////////////////////
+unsigned int HMuMuTree::bestPair(std::vector<unsigned int> &pairIndexes){
+
+  unsigned int bestIndex = 9999;
+  ///Pair are already sorted during the ntuple creation?
+  double iso_1=std::numeric_limits<double>::infinity(), iso_2=std::numeric_limits<double>::infinity(), pt2_1=-1, pt2_2=-1;
+  if(pairIndexes.size()) {
+    //return pairIndexes[0];//MB
+    for(unsigned int ii=0;ii<2*pairIndexes.size();++ii){
+      unsigned int i=(ii<pairIndexes.size()?ii:ii-pairIndexes.size());
+      unsigned int iPair = pairIndexes[i];
+      unsigned int leg1Index = indexDau1->at(iPair);
+      unsigned int leg2Index = indexDau2->at(iPair);
+      if(ii>=pairIndexes.size()){//invert legs
+	leg1Index = indexDau2->at(iPair);
+	leg2Index = indexDau1->at(iPair);
+      }
+      double pt2_1_i = (daughters_px->at(leg1Index)*daughters_px->at(leg1Index)+
+			daughters_py->at(leg1Index)*daughters_py->at(leg1Index));
+      double pt2_2_i = (daughters_px->at(leg2Index)*daughters_px->at(leg2Index)+
+			daughters_py->at(leg2Index)*daughters_py->at(leg2Index));
+      double iso_1_i = combreliso->at(leg1Index);
+      double iso_2_i = combreliso->at(leg2Index);
+      
+      if(iso_1_i>iso_1) continue; 
+      if(pt2_1_i<pt2_1) continue;
+      if(iso_2_i>iso_2) continue; 
+      if(pt2_2_i<pt2_2) continue;
+      bestIndex = iPair;
+      iso_1 = iso_1_i;
+      iso_2 = iso_2_i;
+      pt2_1 = pt2_1_i;
+      pt2_2 = pt2_2_i;
+    }
+  }
+  /*
+  if(pairIndexes.size() && bestIndex!=(Int_t)pairIndexes[0]){
+    unsigned int iPair = pairIndexes[0];
+    unsigned int leg1Index = indexDau1->at(iPair);
+    unsigned int leg2Index = indexDau2->at(iPair);
+    double pt2_1_i = (daughters_px->at(leg1Index)*daughters_px->at(leg1Index)+
+		      daughters_py->at(leg1Index)*daughters_py->at(leg1Index));
+    double pt2_2_i = (daughters_px->at(leg2Index)*daughters_px->at(leg2Index)+
+		      daughters_py->at(leg2Index)*daughters_py->at(leg2Index));
+    std::cout<<"Pair sorting: "<<std::endl
+	     <<"best index = "<<bestIndex<<", index[0] = "<<pairIndexes[0]<<std::endl
+	     <<"\tiso1[best]="<<-iso_1<<", iso1[0]="<<combreliso->at(leg1Index)<<std::endl
+	     <<"\tpt1[best]="<<sqrt(pt2_1)<<", pt1[0]="<<sqrt(pt2_1_i)<<std::endl
+	     <<"\tiso2[best]="<<-iso_2<<", iso1[0]="<<combreliso->at(leg2Index)<<std::endl
+	     <<"\tpt2[best]="<<sqrt(pt2_2)<<", pt1[0]="<<sqrt(pt2_2_i)<<std::endl;
+  }
+  */
+
+  return bestIndex;
+};
+/////////////////////////////////////////////////
+/////////////////////////////////////////////////

--- a/HMuMuTree.h
+++ b/HMuMuTree.h
@@ -22,6 +22,7 @@ class HMuMuTree : public HTauTauTreeBase {
   /////////////////////////////////////////////////
   /// MM final state specific
   bool pairSelection(unsigned int index);
+  unsigned int bestPair(std::vector<unsigned int> &pairIndexes);
   /////////////////////////////////////////////////
   
   HMuMuTree(TTree *tree=0, std::string prefix="WAWMM");

--- a/HTauTauTreeBase.C
+++ b/HTauTauTreeBase.C
@@ -1,3 +1,4 @@
+
 #define HTauTauTreeBase_cxx
 #include "HTauTauTreeBase.h"
 #include <TH2.h>
@@ -703,16 +704,21 @@ Int_t HTauTauTreeBase::Cut(Long64_t entry){
 
   if(!mothers_px->size()) return 9999;
 
-  vector<unsigned int> pairIndexes;
+  std::vector<unsigned int> pairIndexes;
   for(unsigned int iPair=0;iPair<mothers_px->size();++iPair){
     if(pairSelection(iPair)) pairIndexes.push_back(iPair);
   }
+  
+  return bestPair(pairIndexes);
+}
+/////////////////////////////////////////////////
+/////////////////////////////////////////////////
+unsigned int HTauTauTreeBase::bestPair(std::vector<unsigned int> &pairIndexes){
 
   ///Pair are already sorted during the ntuple creation
   if(pairIndexes.size()) return pairIndexes[0];
-  
-  return 9999;
-};
+  else return 9999;
+}
 /////////////////////////////////////////////////
 /////////////////////////////////////////////////
 bool HTauTauTreeBase::pairSelection(unsigned int iPair){
@@ -1066,7 +1072,7 @@ void HTauTauTreeBase::fillPairs(unsigned int bestPairIndex){
 /////////////////////////////////////////////////
 template<class T> T HTauTauTreeBase::getBranchValue(char *branchAddress, unsigned int index){
 
-  vector<T> *aVector = *(vector<T> **)(branchAddress);
+  std::vector<T> *aVector = *(std::vector<T> **)(branchAddress);
 
   if(aVector->size()<=index){
     //std::cout<<"Index - size mismatch "<<std::endl;

--- a/HTauTauTreeBase.h
+++ b/HTauTauTreeBase.h
@@ -37,7 +37,8 @@ public :
   virtual bool extraElectronVeto(unsigned int signalLeg1Index, unsigned int signalLeg2Index, double dRmin=-1);
   bool muonSelection(unsigned int index);
   bool electronSelection(unsigned int index);
-  virtual bool pairSelection(unsigned int index);  
+  virtual bool pairSelection(unsigned int index);
+  virtual unsigned int bestPair(std::vector<unsigned int> &pairIndexes);
   bool jetSelection(unsigned int index, unsigned int bestPairIndex);
   int getMCMatching(unsigned int index);
   bool isGoodToMatch(unsigned int ind);

--- a/HTauhTauhTree.C
+++ b/HTauhTauhTree.C
@@ -93,16 +93,9 @@ bool HTauhTauhTree::pairSelection(unsigned int iPair){
 }
 /////////////////////////////////////////////////
 /////////////////////////////////////////////////
-Int_t HTauhTauhTree::Cut(Long64_t entry){
+unsigned int HTauhTauhTree::bestPair(std::vector<unsigned int> &pairIndexes){
 
-  Int_t bestIndex = 9999;
-  if(!mothers_px->size()) return bestIndex;
-
-  vector<unsigned int> pairIndexes;
-  for(unsigned int iPair=0;iPair<mothers_px->size();++iPair){
-    if(pairSelection(iPair)) pairIndexes.push_back(iPair);
-  }
-
+  unsigned int bestIndex = 9999;
   ///Pair are already sorted during the ntuple creation?
   double iso_1=std::numeric_limits<double>::infinity(), iso_2=std::numeric_limits<double>::infinity(), pt2_1=-1, pt2_2=-1;
   if(pairIndexes.size()) {

--- a/HTauhTauhTree.h
+++ b/HTauhTauhTree.h
@@ -23,7 +23,7 @@ class HTauhTauhTree : public HTauTauTreeBase {
   /////////////////////////////////////////////////
   /// TT final state specific
   bool pairSelection(unsigned int index);
-  Int_t Cut(Long64_t entry);
+  unsigned int bestPair(std::vector<unsigned int> &pairIndexes);
   /////////////////////////////////////////////////
   
   HTauhTauhTree(TTree *tree=0, std::string prefix="WAWTT");


### PR DESCRIPTION
Selection of best pair moved from Cut method to specialized method. Trivial implementation from Base class where 1st pair is returned overridden by specific implementations in the HTauhTauh and HMuMu derived classes. 
