### PR TITLE
SVfit computation added to LLR->WAW converters

### DIFF
--- a/HMuMuTree.h
+++ b/HMuMuTree.h
@@ -33,7 +33,7 @@ class HMuMuTree : public HTauTauTreeBase {
 #endif
 
 #ifdef HMuMuTree_cxx
-HMuMuTree::HMuMuTree(TTree *tree, std::string prefix) : HTauTauTreeBase(tree, prefix) 
+HMuMuTree::HMuMuTree(TTree *tree, std::string prefix) : HTauTauTreeBase(tree, false, prefix) 
 {}
 
 HMuMuTree::~HMuMuTree()

--- a/HTauTauTree.h
+++ b/HTauTauTree.h
@@ -25,7 +25,7 @@ class HTauTauTree : public HTauTauTreeBase {
   bool pairSelection(unsigned int index);
   /////////////////////////////////////////////////
   
-  HTauTauTree(TTree *tree=0, std::string prefix="WAWMT");
+  HTauTauTree(TTree *tree=0, bool doSvFit=false, std::string prefix="WAWMT");
   virtual ~HTauTauTree();
   
 };
@@ -33,7 +33,7 @@ class HTauTauTree : public HTauTauTreeBase {
 #endif
 
 #ifdef HTauTauTree_cxx
-HTauTauTree::HTauTauTree(TTree *tree, std::string prefix) : HTauTauTreeBase(tree, prefix) 
+HTauTauTree::HTauTauTree(TTree *tree, bool doSvFit, std::string prefix) : HTauTauTreeBase(tree, doSvFit, prefix) 
 {}
 
 HTauTauTree::~HTauTauTree()

--- a/HTauTauTreeBase.h
+++ b/HTauTauTreeBase.h
@@ -39,6 +39,7 @@ public :
   bool electronSelection(unsigned int index);
   virtual bool pairSelection(unsigned int index);
   virtual unsigned int bestPair(std::vector<unsigned int> &pairIndexes);
+  void computeSvFit(bool upDownTES=true);
   bool jetSelection(unsigned int index, unsigned int bestPairIndex);
   int getMCMatching(unsigned int index);
   bool isGoodToMatch(unsigned int ind);
@@ -61,6 +62,9 @@ public :
   ScaleFactor myScaleFactor;
   
   unsigned int bestPairIndex_;
+
+  bool doSvFit_;
+  TFile* inputFile_visPtResolution_;
 
   std::vector<std::string> leptonPropertiesList, genLeptonPropertiesList;
 
@@ -633,7 +637,7 @@ public :
    TBranch        *b_pvGen_z;   //!
    TBranch        *b_isRefitPV;   //!
 
-   HTauTauTreeBase(TTree *tree=0, std::string prefix="WAW");
+   HTauTauTreeBase(TTree *tree=0, bool doSvFit=false, std::string prefix="WAW");
    virtual ~HTauTauTreeBase();
    virtual Int_t    Cut(Long64_t entry);
    virtual Int_t    GetEntry(Long64_t entry);

--- a/HTauhTauhTree.h
+++ b/HTauhTauhTree.h
@@ -26,7 +26,7 @@ class HTauhTauhTree : public HTauTauTreeBase {
   unsigned int bestPair(std::vector<unsigned int> &pairIndexes);
   /////////////////////////////////////////////////
   
-  HTauhTauhTree(TTree *tree=0, std::string prefix="WAWTT");
+  HTauhTauhTree(TTree *tree=0, bool doSvFit=false, std::string prefix="WAWTT");
   virtual ~HTauhTauhTree();
   
 };
@@ -34,7 +34,7 @@ class HTauhTauhTree : public HTauTauTreeBase {
 #endif
 
 #ifdef HTauhTauhTree_cxx
-HTauhTauhTree::HTauhTauhTree(TTree *tree, std::string prefix) : HTauTauTreeBase(tree, prefix) 
+HTauhTauhTree::HTauhTauhTree(TTree *tree, bool doSvFit, std::string prefix) : HTauTauTreeBase(tree, doSvFit, prefix) 
 {}
 
 HTauhTauhTree::~HTauhTauhTree()

--- a/makeAndConvert.py
+++ b/makeAndConvert.py
@@ -5,17 +5,21 @@ import os
 from ROOT import gSystem, TChain, TSystem, TFile
 from PSet import process
 
+doSvFit = False
+if doSvFit :
+    print "Run with SVFit computation"
+
 #Produce framework report required by CRAB
 command = "cmsRun -j FrameworkJobReport.xml -p PSet.py"
 os.system(command)
 
 gSystem.CompileMacro('HTTEvent.cxx')
 gSystem.CompileMacro('ScaleFactor.cc')
+gSystem.Load('$CMSSW_BASE/lib/slc6_amd64_gcc530/libTauAnalysisSVfitStandalone.so')
 gSystem.CompileMacro('HTauTauTreeBase.C')
 gSystem.CompileMacro('HTauTauTree.C')
 gSystem.CompileMacro('HTauhTauhTree.C')
 gSystem.CompileMacro('HMuMuTree.C')
-from ROOT import HTauTauTreeBase
 from ROOT import HTauTauTree
 from ROOT import HTauhTauhTree
 from ROOT import HMuMuTree
@@ -29,11 +33,11 @@ print "Making the mu*tau tree"
 aROOTFile = TFile.Open(aFile)
 aTree = aROOTFile.Get("HTauTauTree/HTauTauTree")
 print "TTree entries: ",aTree.GetEntries()
-HTauTauTree(aTree).Loop()
+HTauTauTree(aTree,doSvFit).Loop()
 print "Making the tau*tau tree"
 aROOTFile = TFile.Open(aFile)
 aTree = aROOTFile.Get("HTauTauTree/HTauTauTree")
-HTauhTauhTree(aTree).Loop()
+HTauhTauhTree(aTree,doSVfit).Loop()
 print "Making the mu*mu tree"
 aROOTFile = TFile.Open(aFile)
 aTree = aROOTFile.Get("HTauTauTree/HTauTauTree")

--- a/makeAndConvert_all.py
+++ b/makeAndConvert_all.py
@@ -5,12 +5,17 @@ import os
 from ROOT import gSystem, TChain, TSystem, TFile
 from PSet import process
 
+doSvFit = True
+if doSvFit :
+    print "Run with SVFit computation"
+
 #Produce framework report required by CRAB
 command = "cmsRun -j FrameworkJobReport.xml -p PSet.py"
 os.system(command)
 
 gSystem.CompileMacro('HTTEvent.cxx')
 gSystem.CompileMacro('ScaleFactor.cc')
+gSystem.Load('$CMSSW_BASE/lib/slc6_amd64_gcc530/libTauAnalysisSVfitStandalone.so')
 gSystem.CompileMacro('HTauTauTreeBase.C')
 gSystem.CompileMacro('HTauhTauhTree.C')
 gSystem.CompileMacro('HTauTauTree.C')
@@ -34,22 +39,22 @@ for aFile in fileNames:
     aROOTFile = TFile.Open(aFile)
     aTree = aROOTFile.Get("HTauTauTree/HTauTauTree")
     print "TTree entries: ",aTree.GetEntries()
-    print "Process TT..."
-    HTauhTauhTree(aTree).Loop()
+    print "Process MT..."
+    HTauTauTree(aTree,doSvFit).Loop()
     print "done"
     # file and tree have to be opened again as they are closed by Dtor of analyzer
     aROOTFile = TFile.Open(aFile)
     aTree = aROOTFile.Get("HTauTauTree/HTauTauTree")
     print "TTree entries: ",aTree.GetEntries()
-    print "Process MT..."
-    HTauTauTree(aTree).Loop()
+    print "Process TT..."
+    HTauhTauhTree(aTree,doSvFit).Loop()
     print "done"
     # file and tree have to be opened again as they are closed by Dtor of analyzer
     aROOTFile = TFile.Open(aFile)
     aTree = aROOTFile.Get("HTauTauTree/HTauTauTree")
     print "TTree entries: ",aTree.GetEntries()
     print "Process MM..."
-    HTauTauTree(aTree).Loop()
+    HMuMuTree(aTree).Loop()
     print "done"
 
 #print "TTree entries: ",aTree.GetEntries()

--- a/makeAndConvert_hadr.py
+++ b/makeAndConvert_hadr.py
@@ -5,18 +5,26 @@ import os
 from ROOT import gSystem, TChain, TSystem, TFile
 from PSet import process
 
+doSvFit = True
+if doSvFit :
+    print "Run with SVFit computation"
+
 #Produce framework report required by CRAB
 command = "cmsRun -j FrameworkJobReport.xml -p PSet.py"
 os.system(command)
 
 gSystem.CompileMacro('HTTEvent.cxx')
 gSystem.CompileMacro('ScaleFactor.cc')
+gSystem.Load('$CMSSW_BASE/lib/slc6_amd64_gcc530/libTauAnalysisSVfitStandalone.so')
 gSystem.CompileMacro('HTauTauTreeBase.C')
 gSystem.CompileMacro('HTauhTauhTree.C')
 from ROOT import HTauhTauhTree
 
 fileNames = [
-'/store/user/akalinow/HTauTauAnalysis_TAUCUT_fix.root'
+'/store/user/akalinow/HTauTauAnalysis_TAUCUT_fix.root',
+'/store/user/akalinow/HTauTauAnalysis_MVAMETcorr.root',
+'/store/user/akalinow/HTauTauAnalysis_PFMETcorr.root',
+
 ]
 #aTree = TChain("HTauTauTree/HTauTauTree")
 #for aFile in process.source.fileNames:
@@ -30,7 +38,7 @@ for aFile in fileNames:
     aROOTFile = TFile.Open(aFile)
     aTree = aROOTFile.Get("HTauTauTree/HTauTauTree")
     print "TTree entries: ",aTree.GetEntries()
-    HTauhTauhTree(aTree).Loop()
+    HTauhTauhTree(aTree,doSvFit).Loop()
 
 #print "TTree entries: ",aTree.GetEntries()
 #HTauTauTree(aTree).Loop()


### PR DESCRIPTION
Jak w tytule. 
Obecnie w skrypcie uruchamiajacym konwersje (makeAndConvert.py) SVFit jest domyslnie wylaczony, wlaczenie wymaga zmiany odpowiedniej flagi z False na Truth. Wlaczanie SVFit zalecane w duzej, finalnej produkcji, bo mimo redukcji liczby par zabiera czas: SVfit dla 100 wyselekcjonowanych par H(160)->tau,tau zabiera ok. 20min na Opteronie 2.4GHz a zwykla konwersja <<1min
