### PR TITLE
Add DNN tau-IDs and MVAIso for new DMs

### DIFF
--- a/HTTEvent.cxx
+++ b/HTTEvent.cxx
@@ -37,6 +37,14 @@ const TString HTTEvent::tauIDStrings[ntauIds] = {
    "byTightIsolationMVArun2v1DBoldDMwLT2017v2",
    "byVTightIsolationMVArun2v1DBoldDMwLT2017v2",
    "byVVTightIsolationMVArun2v1DBoldDMwLT2017v2",
+
+   "byVVLooseIsolationMVArun2v1DBnewDMwLT2017v2",
+   "byVLooseIsolationMVArun2v1DBnewDMwLT2017v2",
+   "byLooseIsolationMVArun2v1DBnewDMwLT2017v2",
+   "byMediumIsolationMVArun2v1DBnewDMwLT2017v2",
+   "byTightIsolationMVArun2v1DBnewDMwLT2017v2",
+   "byVTightIsolationMVArun2v1DBnewDMwLT2017v2",
+   "byVVTightIsolationMVArun2v1DBnewDMwLT2017v2",
 };
 
 ////////////////////////////////////////////////

--- a/HTTEvent.h
+++ b/HTTEvent.h
@@ -35,7 +35,7 @@ class HTTEvent{
 
   ///Copy from LLRHiggsTauTau/NtupleProducer/plugins/HTauTauNtuplizer.cc
   // Initialzation of tauIDStrings[] moved to HTTEvent.cxx
-  static const int ntauIds = 24;
+  static const int ntauIds = 31;
   static const TString tauIDStrings[ntauIds];
 
   HTTEvent(){clear();}

--- a/HTauTauTreeBase.C
+++ b/HTauTauTreeBase.C
@@ -207,6 +207,13 @@ void HTauTauTreeBase::Init(TTree *tree)
    //daughters_byIsolationMVA3newDMwLTraw = 0;
    daughters_byIsolationMVArun2v1DBoldDMwLTraw = 0;
    daughters_byIsolationMVArun2v1DBoldDMwLTraw2017v2 = 0;
+   daughters_byIsolationMVArun2v1DBnewDMwLTraw2017v2 = 0;
+   daughters_deepTau2017v1tauVSe = 0;
+   daughters_deepTau2017v1tauVSmu = 0;
+   daughters_deepTau2017v1tauVSjet = 0;
+   daughters_deepTau2017v1tauVSall = 0;
+   daughters_DPFTau_2016_v0tauVSall = 0;
+   daughters_DPFTau_2016_v1tauVSall = 0;
    daughters_chargedIsoPtSum = 0;
    daughters_neutralIsoPtSum = 0;
    daughters_chargedIsoPtSumdR03 = 0;
@@ -443,6 +450,13 @@ void HTauTauTreeBase::Init(TTree *tree)
    //fChain->SetBranchAddress("daughters_byIsolationMVA3newDMwLTraw", &daughters_byIsolationMVA3newDMwLTraw, &b_daughters_byIsolationMVA3newDMwLTraw);
    fChain->SetBranchAddress("daughters_byIsolationMVArun2v1DBoldDMwLTraw", &daughters_byIsolationMVArun2v1DBoldDMwLTraw, &b_daughters_byIsolationMVArun2v1DBoldDMwLTraw);
    fChain->SetBranchAddress("daughters_byIsolationMVArun2v1DBoldDMwLTraw2017v2", &daughters_byIsolationMVArun2v1DBoldDMwLTraw2017v2, &b_daughters_byIsolationMVArun2v1DBoldDMwLTraw2017v2);
+   fChain->SetBranchAddress("daughters_byIsolationMVArun2v1DBnewDMwLTraw2017v2", &daughters_byIsolationMVArun2v1DBnewDMwLTraw2017v2, &b_daughters_byIsolationMVArun2v1DBnewDMwLTraw2017v2);
+   fChain->SetBranchAddress("daughters_deepTau2017v1tauVSe", &daughters_deepTau2017v1tauVSe, &b_daughters_deepTau2017v1tauVSe);
+   fChain->SetBranchAddress("daughters_deepTau2017v1tauVSmu", &daughters_deepTau2017v1tauVSmu, &b_daughters_deepTau2017v1tauVSmu);
+   fChain->SetBranchAddress("daughters_deepTau2017v1tauVSjet", &daughters_deepTau2017v1tauVSjet, &b_daughters_deepTau2017v1tauVSjet);
+   fChain->SetBranchAddress("daughters_deepTau2017v1tauVSall", &daughters_deepTau2017v1tauVSall, &b_daughters_deepTau2017v1tauVSall);
+   fChain->SetBranchAddress("daughters_DPFTau_2016_v0tauVSall", &daughters_DPFTau_2016_v0tauVSall, &b_daughters_DPFTau_2016_v0tauVSall);
+   fChain->SetBranchAddress("daughters_DPFTau_2016_v1tauVSall", &daughters_DPFTau_2016_v1tauVSall, &b_daughters_DPFTau_2016_v1tauVSall);
    fChain->SetBranchAddress("daughters_chargedIsoPtSum", &daughters_chargedIsoPtSum, &b_daughters_chargedIsoPtSum);
    fChain->SetBranchAddress("daughters_neutralIsoPtSum", &daughters_neutralIsoPtSum, &b_daughters_neutralIsoPtSum);
    fChain->SetBranchAddress("daughters_chargedIsoPtSumdR03", &daughters_chargedIsoPtSumdR03, &b_daughters_chargedIsoPtSumdR03);
@@ -620,6 +634,15 @@ void HTauTauTreeBase::initWawTree(TTree *tree, std::string prefix){
   leptonPropertiesList.push_back("bDiscriminator");
   leptonPropertiesList.push_back("bCSVscore");
   leptonPropertiesList.push_back("PFjetID");
+
+  leptonPropertiesList.push_back("daughters_byIsolationMVArun2v1DBnewDMwLTraw2017v2");
+  leptonPropertiesList.push_back("daughters_deepTau2017v1tauVSe");
+  leptonPropertiesList.push_back("daughters_deepTau2017v1tauVSmu");
+  leptonPropertiesList.push_back("daughters_deepTau2017v1tauVSjet");
+  leptonPropertiesList.push_back("daughters_deepTau2017v1tauVSall");
+  leptonPropertiesList.push_back("daughters_DPFTau_2016_v0tauVSall");
+  leptonPropertiesList.push_back("daughters_DPFTau_2016_v1tauVSall");
+
   ////////////////////////////////////////////////////////////
   ///Gen Lepton properties MUST be synchronized with lepton properties
   ///since the branches name are not uniform, we need a second names vector.

--- a/HTauTauTreeBase.h
+++ b/HTauTauTreeBase.h
@@ -243,6 +243,13 @@ public :
    //vector<double>  *daughters_byIsolationMVA3newDMwLTraw;
    vector<double>  *daughters_byIsolationMVArun2v1DBoldDMwLTraw;
    vector<double>  *daughters_byIsolationMVArun2v1DBoldDMwLTraw2017v2;
+   vector<double>  *daughters_byIsolationMVArun2v1DBnewDMwLTraw2017v2;
+   vector<double>  *daughters_deepTau2017v1tauVSe;
+   vector<double>  *daughters_deepTau2017v1tauVSmu;
+   vector<double>  *daughters_deepTau2017v1tauVSjet;
+   vector<double>  *daughters_deepTau2017v1tauVSall;
+   vector<double>  *daughters_DPFTau_2016_v0tauVSall;
+   vector<double>  *daughters_DPFTau_2016_v1tauVSall;
    vector<double>  *daughters_chargedIsoPtSum;
    vector<double>  *daughters_neutralIsoPtSum;
    vector<double>  *daughters_chargedIsoPtSumdR03;
@@ -488,6 +495,13 @@ public :
    //TBranch        *b_daughters_byIsolationMVA3newDMwLTraw;   //!
    TBranch        *b_daughters_byIsolationMVArun2v1DBoldDMwLTraw;   //!
    TBranch        *b_daughters_byIsolationMVArun2v1DBoldDMwLTraw2017v2;   //!
+   TBranch        *b_daughters_byIsolationMVArun2v1DBnewDMwLTraw2017v2;   //!
+   TBranch        *b_daughters_deepTau2017v1tauVSe;   //!
+   TBranch        *b_daughters_deepTau2017v1tauVSmu;   //!
+   TBranch        *b_daughters_deepTau2017v1tauVSjet;   //!
+   TBranch        *b_daughters_deepTau2017v1tauVSall;   //!
+   TBranch        *b_daughters_DPFTau_2016_v0tauVSall;   //!
+   TBranch        *b_daughters_DPFTau_2016_v1tauVSall;   //!
    TBranch        *b_daughters_chargedIsoPtSum;   //!
    TBranch        *b_daughters_neutralIsoPtSum;   //!
    TBranch        *b_daughters_chargedIsoPtSumdR03;   //!

--- a/PropertyEnum.h
+++ b/PropertyEnum.h
@@ -26,5 +26,12 @@ Flavour = 24,
 bDiscriminator = 25, 
 bCSVscore = 26, 
 PFjetID = 27, 
-NONE = 28
+byIsolationMVArun2v1DBnewDMwLTraw2017v2 = 28, 
+deepTau2017v1tauVSe = 29, 
+deepTau2017v1tauVSmu = 30, 
+deepTau2017v1tauVSjet = 31, 
+deepTau2017v1tauVSall = 32, 
+DPFTau_2016_v0tauVSall = 33, 
+DPFTau_2016_v1tauVSall = 34, 
+NONE = 35
 };


### PR DESCRIPTION
Tak jak w tytule: DNN Tau-ID oraz MVAIso 2017v2 dla nowych DM dodane do ntupli, ale bez zmiany logiki tj. sortowania po innym tau-Id oraz selekcji. Zmiany zgodne z ostatnimi rozszerzeniami `LLRAnalysis`. 
Zmiana logiki w celu zobaczenia ew. zysku z uzycia nowych DM i/lub nowych tau-ID do przemyslenia i wprowadzenia w nowej galezi / branchu.

Rozszerzony `PropertyEnum.h` powinien byc przekopiowany do RootAnalysis co zostawiam @akalinow.  