### PR TITLE
DNN TauIDs for Run2017 production with Crab

### DIFF
--- a/crab3.py
+++ b/crab3.py
@@ -20,7 +20,7 @@ config.Data.totalUnits =  -1 #number of event
 config.Data.outLFNDirBase = '/store/user/akalinow/EnrichedMiniAOD/WplusHToTauTau_M120_v1/'
 config.Data.publication = False
 config.Data.outputDatasetTag = 'WplusHToTauTau_M120_v1'
-
+config.JobType.maxMemoryMB = 3500 # default is 2000, 2500 is granted at T2s (but it is usually less than available, DNNs require more)
 
 
 config.section_("Site")

--- a/makeAndConvert.py
+++ b/makeAndConvert.py
@@ -8,6 +8,12 @@ doSvFit = True
 if doSvFit :
     print "Run with SVFit computation"
 
+#Checkout DNN training files
+command = "cd $CMSSW_BASE/src; "
+command += "git clone https://github.com/cms-tau-pog/RecoTauTag-TrainingFiles -b master RecoTauTag/TrainingFiles/data; "
+command += "cd -;"
+os.system(command)
+
 #Some system have problem runnig compilation (missing glibc-static library?).
 #First we try to compile, and only then we start time consuming cmssw
 status = gSystem.CompileMacro('HTTEvent.cxx')


### PR DESCRIPTION
DeepTauId i DPFTauId dodane do `Production` wraz z możliwością puszczania jobow Crabem. Wymagało to dodania checkoutowania plikow treningowych do skryptu `makeAndConvert.py` oraz zażądania więcej pamieci na job (default jest 2000MB, żądany 3500MB). 
Uwaga! Żeby wysłać joby Crabem trzeba najpierw usunąć pliki z danymi treningowymi z lokalnego drzewa CMSSW:
```
rm -rf $CMSSW_BASE/external/$SCRAM_ARCH/data/RecoTauTag/TrainingFiles/data
```
lub 
```
rm -rf $CMSSW_BASE/src/RecoTauTag/TrainingFiles/data
```
w zależności od tego gdzie zostały umieszczone.
 
Jak na razie testy z próbką ggH są pomyslne, ale tylko jeden job z 5k przypadków sie skończył. Zamierzam jeszcze wysłać joby z ttbar, które jest bardziej wymagające, żeby ew. dotunować ilość wymaganej pamięci.
